### PR TITLE
MOP-32 added the restore-cache steps back into circle build - also pinned npm version to 9.2.0 resolve npm ci issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,9 @@ jobs:
       - checkout
       - run:
           name: Update npm
-          command: 'sudo npm install -g npm@latest'
+          command: 'sudo npm install -g npm@9.2.0'
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install Dependencies
           command: npm ci --no-audit
@@ -60,6 +62,8 @@ jobs:
       tag: << pipeline.parameters.node-version >>
     steps:
       - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: install-npm
           command: 'npm ci --no-audit'


### PR DESCRIPTION
See https://mojdt.slack.com/archives/C69NWE339/p1673607422599409
resolves 
npm ERR! code ERR_FS_EISDIR
npm ERR! syscall rm
npm ERR! path /home/circleci/app/node_modules/.bin
npm ERR! errno 21