### PR TITLE
MOP-154 Create two lists for different criteria

### DIFF
--- a/server/@types/manageOffences/index.d.ts
+++ b/server/@types/manageOffences/index.d.ts
@@ -318,8 +318,10 @@ export interface components {
     }
     /** @description Contains the list of all the offences that are sexual (Schedule 3 or 15 Part 2) or violent (Schedule 15 Part 1) */
     SexualOrViolentLists: {
+      /** @description Offence code starts with SX03 or SX56 or is in Schedule 15, Part 2 */
+      sexualCodesAndS15P2: components['schemas']['OffenceToScheduleMapping'][]
       /** @description Offence is in Schedule 3 or Schedule 15, Part 2 */
-      sexual: components['schemas']['OffenceToScheduleMapping'][]
+      sexualS3AndS15P2: components['schemas']['OffenceToScheduleMapping'][]
       /** @description Offence is in Schedule 15, Part 1 */
       violent: components['schemas']['OffenceToScheduleMapping'][]
     }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -14,7 +14,7 @@ export default function Index(services: Services): Router {
   router.use(searchRoutes(services.offenceService, services.adminService))
   router.use(loadResultsRoutes(services.adminService))
   router.use(toggleJobs(services.adminService))
-  router.use(scheduleRoutes(services.offenceService))
+  router.use(scheduleRoutes(services.offenceService, services.adminService))
   router.use(changeHistory(services.adminService))
 
   return router

--- a/server/routes/schedules/handlers/partsAndOffences.test.ts
+++ b/server/routes/schedules/handlers/partsAndOffences.test.ts
@@ -6,10 +6,13 @@ import {
   OffenceToScheduleMapping,
   SexualOrViolentLists,
 } from '../../../@types/manageOffences/manageOffencesClientTypes'
+import AdminService from '../../../services/adminService'
+import FeatureToggleDisplay from '../../../types/featureToggleDisplay'
 
 jest.mock('../../../services/offenceService')
 
 const offenceService = new OffenceService(null) as jest.Mocked<OffenceService>
+const adminService = new AdminService(null, null) as jest.Mocked<AdminService>
 
 const offence1: OffenceToScheduleMapping = {
   id: 1,
@@ -50,13 +53,17 @@ const offence3: OffenceToScheduleMapping = {
   legislationText: 'Legislation text 3',
 }
 
-const sexualOrViolentLists: SexualOrViolentLists = { sexual: [offence1, offence2], violent: [offence3] }
+const sexualOrViolentLists: SexualOrViolentLists = {
+  sexualCodesAndS15P2: [offence1],
+  sexualS3AndS15P2: [offence2],
+  violent: [offence3],
+}
 
 let app: Express
 
 beforeEach(() => {
   app = appWithAllRoutes({
-    services: { offenceService },
+    services: { offenceService, adminService },
   })
 })
 afterEach(() => {
@@ -66,6 +73,16 @@ afterEach(() => {
 describe('', () => {
   it('should navigate to the Sexual or Violent Offences page', () => {
     offenceService.getSexualOrViolentLists.mockResolvedValue(sexualOrViolentLists)
+    adminService.getFeatureToggles = jest.fn()
+    const featureToggleDisplays = [
+      {
+        feature: 'SEXUAL_OFFENCES_FROM_CODES_AND_S15P2',
+        enabled: true,
+        displayName: 'SEXUAL_OFFENCES_FROM_CODES_AND_S15P2',
+      } as unknown as FeatureToggleDisplay,
+    ]
+
+    adminService.getFeatureToggles.mockResolvedValue(featureToggleDisplays)
 
     return request(app)
       .get('/schedules/sexual-or-violent-lists')
@@ -73,18 +90,53 @@ describe('', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         expect(res.text).toContain('Sexual or Violent Offences')
+        expect(res.text).toContain('offence codes that begin with SX03 or SX56 or inclusion in Schedule 15 Part 2')
+      })
+  })
+
+  it('when the toggle is false, the correct table should be identified', () => {
+    offenceService.getSexualOrViolentLists.mockResolvedValue(sexualOrViolentLists)
+    adminService.getFeatureToggles = jest.fn()
+    const featureToggleDisplays = [
+      {
+        feature: 'SEXUAL_OFFENCES_FROM_CODES_AND_S15P2',
+        enabled: false,
+        displayName: 'SEXUAL_OFFENCES_FROM_CODES_AND_S15P2',
+      } as unknown as FeatureToggleDisplay,
+    ]
+
+    adminService.getFeatureToggles.mockResolvedValue(featureToggleDisplays)
+
+    return request(app)
+      .get('/schedules/sexual-or-violent-lists')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Sexual or Violent Offences')
+        expect(res.text).toContain('inclusion in Schedule 3 or Schedule 15 Part 2')
       })
   })
 
   it('the sexual tab should contain the sexual offences', () => {
     offenceService.getSexualOrViolentLists.mockResolvedValue(sexualOrViolentLists)
 
+    adminService.getFeatureToggles = jest.fn()
+    const featureToggleDisplays = [
+      {
+        feature: 'SEXUAL_OFFENCES_FROM_CODES_AND_S15P2',
+        enabled: true,
+        displayName: 'SEXUAL_OFFENCES_FROM_CODES_AND_S15P2',
+      } as unknown as FeatureToggleDisplay,
+    ]
+
+    adminService.getFeatureToggles.mockResolvedValue(featureToggleDisplays)
+
     return request(app)
-      .get('/schedules/sexual-or-violent-lists#sexual')
+      .get('/schedules/sexual-or-violent-lists#sexual-s3-and-s15p2')
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {
-        expect(res.text).toContain('Sexual Offences (Schedule 3 or Schedule 15 Part 2)')
+        expect(res.text).toContain('Codes that begin with SX03 or SX56 or are in Schedule 15 Part 2')
         expect(res.text).toContain('AA1234')
         expect(res.text).toContain('BB1234')
         expect(res.text).toContain('Legislation text 2')
@@ -95,6 +147,16 @@ describe('', () => {
 
   it('the violent tab should contain the violent offences', () => {
     offenceService.getSexualOrViolentLists.mockResolvedValue(sexualOrViolentLists)
+    adminService.getFeatureToggles = jest.fn()
+    const featureToggleDisplays = [
+      {
+        feature: 'SEXUAL_OFFENCES_FROM_CODES_AND_S15P2',
+        enabled: true,
+        displayName: 'SEXUAL_OFFENCES_FROM_CODES_AND_S15P2',
+      } as unknown as FeatureToggleDisplay,
+    ]
+
+    adminService.getFeatureToggles.mockResolvedValue(featureToggleDisplays)
 
     return request(app)
       .get('/schedules/sexual-or-violent-lists#violent')

--- a/server/routes/schedules/handlers/partsAndOffences.ts
+++ b/server/routes/schedules/handlers/partsAndOffences.ts
@@ -1,8 +1,13 @@
 import { Request, Response } from 'express'
 import OffenceService from '../../../services/offenceService'
+import AdminService from '../../../services/adminService'
+import FeatureToggleType from '../../../types/featureToggleType'
 
 export default class PartsAndOffencesRoutes {
-  constructor(private readonly offenceService: OffenceService) {}
+  constructor(
+    private readonly offenceService: OffenceService,
+    private readonly adminService: AdminService,
+  ) {}
 
   GET = async (req: Request, res: Response): Promise<void> => {
     const { scheduleId } = req.params
@@ -25,9 +30,14 @@ export default class PartsAndOffencesRoutes {
 
   GET_SEXUAL_AND_VIOLENT_LISTS = async (req: Request, res: Response): Promise<void> => {
     const sexualOrViolentLists = await this.offenceService.getSexualOrViolentLists(res.locals.user)
-
+    const sexualFromCodesAndS15P2 = (await this.adminService.getFeatureToggles(res.locals.user)).find(
+      i => i.feature === FeatureToggleType.SEXUAL_OFFENCES_FROM_CODES_AND_S15P2.featureName,
+    ).enabled
+    const sexualFromS3AndS15P2 = !sexualFromCodesAndS15P2
     res.render('pages/schedules/sexualOrViolentLists', {
       sexualOrViolentLists,
+      sexualFromCodesAndS15P2,
+      sexualFromS3AndS15P2,
     })
   }
 }

--- a/server/routes/schedules/index.ts
+++ b/server/routes/schedules/index.ts
@@ -4,6 +4,7 @@ import ScheduleRoutes from './handlers/schedules'
 import LinkOffenceRoutes from './handlers/linkOffence'
 import OffenceService from '../../services/offenceService'
 import PartsAndOffencesRoutes from './handlers/partsAndOffences'
+import AdminService from '../../services/adminService'
 
 export const schedulePaths = {
   LINK_OFFENCE_POST: '/schedules/link-offence', // TODO REMOVE
@@ -12,14 +13,14 @@ export const schedulePaths = {
   LINK_OFFENCE_CREATE: '/schedules/link-offence/create',
 }
 
-export default function Index(offenceService: OffenceService): Router {
+export default function Index(offenceService: OffenceService, adminService: AdminService): Router {
   const router = Router()
   const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
   const post = (path: string, handler: RequestHandler) => router.post(path, asyncMiddleware(handler))
 
   const scheduleHandler = new ScheduleRoutes(offenceService)
   const linkOffenceRoutes = new LinkOffenceRoutes(offenceService)
-  const partsAndOffencesHandler = new PartsAndOffencesRoutes(offenceService)
+  const partsAndOffencesHandler = new PartsAndOffencesRoutes(offenceService, adminService)
 
   get('/schedules', scheduleHandler.GET)
   get('/schedules/parts-and-offences/:scheduleId', partsAndOffencesHandler.GET)

--- a/server/views/pages/schedules/sexualOrViolentLists.njk
+++ b/server/views/pages/schedules/sexualOrViolentLists.njk
@@ -10,65 +10,88 @@
 {% set pageId = "schedules" %}
 
 {% block navBar %}
-  {{ navBar("schedules") }}
+    {{ navBar("schedules") }}
 {% endblock %}
 
 {% block aside %}
-  {{ govukBreadcrumbs({
-    items: [
-      {
-        text: "Home",
-        href: "/"
-      },
-      {
-        text: "Sexual or Violent Offences"
-      }
-    ]
-  }) }}
+    {{ govukBreadcrumbs({
+        items: [
+            {
+                text: "Home",
+                href: "/"
+            },
+            {
+                text: "Sexual or Violent Offences"
+            }
+        ]
+    }) }}
 {% endblock %}
 
       {% block content %}
-        <h1 class="govuk-heading-l">
-          Sexual or Violent Offences
-        </h1>
+          <h1 class="govuk-heading-l">
+              Sexual or Violent Offences
+          </h1>
+          <h2 class="govuk-label">
+              The Manage Offences API currently identifies sexual offences by
+              {% if sexualFromCodesAndS15P2 %}
+                  offence codes that begin with SX03 or SX56 or inclusion in Schedule 15 Part 2
+              {% else %}
+                  inclusion in Schedule 3 or Schedule 15 Part 2
+              {% endif %}
+          </h2>
+          <p></p>
+          {{ govukTabs({
+              classes: 'borderless-tabs',
+              items: [
+                  {
+                      label: "Sexual",
+                      id: "sexual-codes-and-s15p2",
+                      panel: {
+                      html: pcscTab(sexualOrViolentLists.sexualCodesAndS15P2, 'Codes that begin with SX03 or SX56 or are in Schedule 15 Part 2',sexualFromCodesAndS15P2, true)
+                  }
+                  },
+                  {
+                      label: "Violent",
+                      id: "violent",
+                      panel: {
+                      html: pcscTab(sexualOrViolentLists.violent, 'Violent Offences (Schedule 15 Part 1)', false, false)
+                  }
+                  },
+                  {
+                      label: "Sexual - Schedule 3 and 15 Part 2",
+                      id: "sexual-s3-and-s15p2",
+                      panel: {
+                      html: pcscTab(sexualOrViolentLists.sexualS3AndS15P2, 'Codes that are in Schedule 3 or Schedule 15 Part 2)', sexualFromS3AndS15P2, true)
+                  }
+                  }
+              ]
+          }) }}
 
-        {{ govukTabs({
-          classes: 'borderless-tabs',
-          items: [
-            {
-              label: "Sexual",
-              id: "sexual",
-              panel: {
-              html: pcscTab(sexualOrViolentLists.sexual, 'Sexual Offences (Schedule 3 or Schedule 15 Part 2)')
-            }
-            },{
-              label: "Violent",
-              id: "violent",
-              panel: {
-                html: pcscTab(sexualOrViolentLists.violent, 'Violent Offences (Schedule 15 Part 1)')
-              }
-            }
-          ]
-        }) }}
-
-        {{ govukBackLink({
-          text: "Back",
-          href: "/"
-        }) }}
+          {{ govukBackLink({
+              text: "Back",
+              href: "/"
+          }) }}
       {% endblock %}
 
-      {% macro pcscTab(list, partDesc) %}
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-full govuk-!-text-align-left">
-            <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-              {{ partDesc }}
-            </h2>
+      {% macro pcscTab(list, partDesc, active, hint) %}
+          <div class="govuk-grid-row">
+              <div class="govuk-grid-column-full govuk-!-text-align-left">
+                  {% if hint %}
+                      <span class="govuk-caption-m"> This table is
+                      {% if active %}
+                      {% else %}
+                          not
+                      {% endif %} currently used by the api to identify sexual offences</span>
+                  {% endif %}
+                  <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
+                      {{ partDesc }}
+                  </h2>
+              </div>
           </div>
-        </div>
-        {{ scheduleOffenceListTable(
-          {
-            offences: list,
-            showMaxPeriodAndParagraph: false
-          }
-        ) }}
+          {{ scheduleOffenceListTable(
+              {
+                  offences: list,
+                  showMaxPeriodAndParagraph: false
+              }
+          ) }}
       {% endmacro %}


### PR DESCRIPTION
Displays the two different lists that are used to determine a sexual offence. View also shows the user which criteria is currently being used by the api.