### PR TITLE
MOP-156 Remove third tab from sexual-and-violent-offences page and add Offence markers section to view offence page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4554,6 +4554,7 @@
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
       "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",

--- a/server/@types/manageOffences/manageOffencesClientTypes.ts
+++ b/server/@types/manageOffences/manageOffencesClientTypes.ts
@@ -19,3 +19,13 @@ export type NomisHistoryRecords = {
   updatedOffences: NomisChangeHistory[]
   statutes: NomisChangeHistory[]
 }
+
+export type OffenceMarkers = {
+  markersExist: boolean
+  isSexual: boolean
+  isViolent: boolean
+  inListA: boolean
+  inListB: boolean
+  inListC: boolean
+  inListD: boolean
+}

--- a/server/routes/schedules/handlers/partsAndOffences.test.ts
+++ b/server/routes/schedules/handlers/partsAndOffences.test.ts
@@ -117,34 +117,6 @@ describe('', () => {
       })
   })
 
-  it('the sexual tab should contain the sexual offences', () => {
-    offenceService.getSexualOrViolentLists.mockResolvedValue(sexualOrViolentLists)
-
-    adminService.getFeatureToggles = jest.fn()
-    const featureToggleDisplays = [
-      {
-        feature: 'SEXUAL_OFFENCES_FROM_CODES_AND_S15P2',
-        enabled: true,
-        displayName: 'SEXUAL_OFFENCES_FROM_CODES_AND_S15P2',
-      } as unknown as FeatureToggleDisplay,
-    ]
-
-    adminService.getFeatureToggles.mockResolvedValue(featureToggleDisplays)
-
-    return request(app)
-      .get('/schedules/sexual-or-violent-lists#sexual-s3-and-s15p2')
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        expect(res.text).toContain('Codes that begin with SX03 or SX56 or are in Schedule 15 Part 2')
-        expect(res.text).toContain('AA1234')
-        expect(res.text).toContain('BB1234')
-        expect(res.text).toContain('Legislation text 2')
-        expect(res.text).toContain('Offence 2')
-        expect(res.text).toContain('06 Jan 1994')
-      })
-  })
-
   it('the violent tab should contain the violent offences', () => {
     offenceService.getSexualOrViolentLists.mockResolvedValue(sexualOrViolentLists)
     adminService.getFeatureToggles = jest.fn()

--- a/server/routes/search/handlers/search.ts
+++ b/server/routes/search/handlers/search.ts
@@ -29,12 +29,14 @@ export default class SearchRoutes {
       !offence.isChild && (await this.offenceService.getOffencesByIds(offence.childOffenceIds, res.locals.user))
     const parentOffence =
       offence.isChild && (await this.offenceService.getOffenceById(offence.parentOffenceId, res.locals.user))
+    const offenceMarkers = await this.offenceService.getOffenceMarkers(offence, res.locals.user)
     res.render('pages/search/viewOffence', {
       offence,
       offenceCodeSearch,
       childOffences,
       parentOffence,
       nomisActivationFlags,
+      offenceMarkers,
     })
   }
 }

--- a/server/services/offenceService.ts
+++ b/server/services/offenceService.ts
@@ -2,6 +2,7 @@ import ManageOffencesApiClient from '../data/manageOffencesApiClient'
 import {
   LinkOffence,
   Offence,
+  OffenceMarkers,
   OffenceToScheduleMapping,
   PcscLists,
   Schedule,
@@ -73,5 +74,33 @@ export default class OffenceService {
 
   async getPcscLists(user: User): Promise<PcscLists> {
     return this.manageOffencesApi.getPcscLists(user)
+  }
+
+  async getOffenceMarkers(offence: Offence, user: User): Promise<OffenceMarkers> {
+    const [sexualOrViolentLists, pcscLists] = await Promise.all([
+      this.getSexualOrViolentLists(user),
+      this.getPcscLists(user),
+    ])
+
+    const isCodeInList = (list: { code: string }[], code: string) => list.some(item => item.code === code)
+
+    const isSexual = isCodeInList(sexualOrViolentLists.sexualCodesAndS15P2, offence.code)
+    const isViolent = isCodeInList(sexualOrViolentLists.violent, offence.code)
+    const inListA = isCodeInList(pcscLists.listA, offence.code)
+    const inListB = isCodeInList(pcscLists.listB, offence.code)
+    const inListC = isCodeInList(pcscLists.listC, offence.code)
+    const inListD = isCodeInList(pcscLists.listD, offence.code)
+
+    const markersExist = isSexual || isViolent || inListA || inListB || inListC || inListD
+
+    return {
+      isSexual,
+      isViolent,
+      inListA,
+      inListB,
+      inListC,
+      inListD,
+      markersExist,
+    }
   }
 }

--- a/server/views/pages/schedules/sexualOrViolentLists.njk
+++ b/server/views/pages/schedules/sexualOrViolentLists.njk
@@ -56,13 +56,6 @@
                       panel: {
                       html: pcscTab(sexualOrViolentLists.violent, 'Violent Offences (Schedule 15 Part 1)', false, false)
                   }
-                  },
-                  {
-                      label: "Sexual - Schedule 3 and 15 Part 2",
-                      id: "sexual-s3-and-s15p2",
-                      panel: {
-                      html: pcscTab(sexualOrViolentLists.sexualS3AndS15P2, 'Codes that are in Schedule 3 or Schedule 15 Part 2)', sexualFromS3AndS15P2, true)
-                  }
                   }
               ]
           }) }}

--- a/server/views/pages/search/viewOffence.njk
+++ b/server/views/pages/search/viewOffence.njk
@@ -5,6 +5,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 {% from "partials/offenceDetailsSection.njk" import offenceDetailsSection %}
+{% from "partials/offenceMarkersSection.njk" import offenceMarkersSection %}
 {% from "partials/inchoateTable.njk" import inchoateTable %}
 {% from "partials/scheduleCards.njk" import scheduleCards %}
 
@@ -41,38 +42,8 @@
     {{ offence.code }}: {{ offence.description }}
   </h1>
 
-
   {{ offenceDetailsSection(offence, parentOffence, {nomisActivationFlags: nomisActivationFlags, offenceCodeSearch: offenceCodeSearch, csrfToken: csrfToken}) }}
-
-  <div class="govuk-grid-row govuk-body">
-    <div class="govuk-grid-column-full">
-      <h2 class="govuk-heading-m">Offence Markers: PCSC, Violent or Sexual</h2>
-      {% if offenceMarkers.markersExist %}
-        <ul class="govuk-list" id="offence-markers">
-          {% if offenceMarkers.isSexual %}
-            <li>Sexual</li>
-          {% endif %}
-          {% if offenceMarkers.isViolent %}
-            <li>Violent</li>
-          {% endif %}
-          {% if offenceMarkers.inListA %}
-            <li>SDS >7 years between 01 April 2020 and 28 June 2022</li>
-          {% endif %}
-          {% if offenceMarkers.inListB %}
-            <li>SDS between 4 and 7 years after 28 June 2022</li>
-          {% endif %}
-          {% if offenceMarkers.inListC %}
-            <li>Sec250 >7 years after 28 June 2022</li>
-          {% endif %}
-          {% if offenceMarkers.inListD %}
-            <li>SDS >7 years after 28 June 2022</li>
-          {% endif %}
-        </ul>
-      {% else %}
-        <p id="no-offence-markers" class="govuk-!-margin-bottom-0">None</p>
-      {% endif %}
-    </div>
-  </div>
+  {{ offenceMarkersSection(offenceMarkers) }}
 
   <div class="govuk-grid-row govuk-body">
     <div class="govuk-grid-column-full">

--- a/server/views/pages/search/viewOffence.njk
+++ b/server/views/pages/search/viewOffence.njk
@@ -12,70 +12,100 @@
 {% set pageId = "view-offence" %}
 
 {% block navBar %}
-    {{ navBar('search') }}
+  {{ navBar('search') }}
 {% endblock %}
 
-{% if offenceCodeSearch !== undefined%}
-    {% set searchUrl = "/search/offence-code?offenceCode=" + offenceCodeSearch %}
+{% if offenceCodeSearch !== undefined %}
+  {% set searchUrl = "/search/offence-code?offenceCode=" + offenceCodeSearch %}
 {% else %}
-    {% set searchUrl = "/search/offence-code"%}
+  {% set searchUrl = "/search/offence-code" %}
 {% endif %}
 
 {% block aside %}
-    {{ govukBreadcrumbs({
-        items: [
-            {
-                text: "Search " + (offenceCodeSearch or ''),
-                href: searchUrl
-            },
-            {
-                text: "View " + offence.code
-            }
-        ]
-    }) }}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Search " + (offenceCodeSearch or ''),
+        href: searchUrl
+      },
+      {
+        text: "View " + offence.code
+      }
+    ]
+  }) }}
 {% endblock %}
 
 {% block content %}
 
-    <h1 class="govuk-heading-l">
-        {{ offence.code }}: {{ offence.description }}
-    </h1>
+  <h1 class="govuk-heading-l">
+    {{ offence.code }}: {{ offence.description }}
+  </h1>
 
 
-    {{ offenceDetailsSection(offence, parentOffence, {nomisActivationFlags: nomisActivationFlags, offenceCodeSearch: offenceCodeSearch, csrfToken: csrfToken}) }}
+  {{ offenceDetailsSection(offence, parentOffence, {nomisActivationFlags: nomisActivationFlags, offenceCodeSearch: offenceCodeSearch, csrfToken: csrfToken}) }}
 
-    <div class="govuk-grid-row govuk-body">
-        <div class="govuk-grid-column-full">
-            <h2 class="govuk-heading-m">Linked schedules</h2>
-            {% if offence.schedules.length == 0 %}
-                <p class="govuk-!-margin-bottom-0">None</p>
-            {% else %}
-                {{ scheduleCards(offence.schedules) }}
-            {% endif %}
-
-        </div>
+  <div class="govuk-grid-row govuk-body">
+    <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-m">Offence Markers: PCSC, Violent or Sexual</h2>
+      {% if offenceMarkers.markersExist %}
+        <ul class="govuk-list" id="offence-markers">
+          {% if offenceMarkers.isSexual %}
+            <li>Sexual</li>
+          {% endif %}
+          {% if offenceMarkers.isViolent %}
+            <li>Violent</li>
+          {% endif %}
+          {% if offenceMarkers.inListA %}
+            <li>SDS >7 years between 01 April 2020 and 28 June 2022</li>
+          {% endif %}
+          {% if offenceMarkers.inListB %}
+            <li>SDS between 4 and 7 years after 28 June 2022</li>
+          {% endif %}
+          {% if offenceMarkers.inListC %}
+            <li>Sec250 >7 years after 28 June 2022</li>
+          {% endif %}
+          {% if offenceMarkers.inListD %}
+            <li>SDS >7 years after 28 June 2022</li>
+          {% endif %}
+        </ul>
+      {% else %}
+        <p id="no-offence-markers" class="govuk-!-margin-bottom-0">None</p>
+      {% endif %}
     </div>
+  </div>
 
-    {% if not offence.isChild %}
-        <div class="govuk-grid-row govuk-body">
-            <div class="govuk-grid-column-full">
-                {% if not childOffences or childOffences.length == 0 %}
-                    <h1 class="govuk-heading-m">Associated inchoate offences</h1>
-                    <p class="govuk-!-margin-bottom-0">None</p>
-                {% else %}
-                    <h1 class="govuk-heading-m">Associated inchoate offences</h1>
-                    {{ inchoateTable(childOffences) }}
-                {% endif %}
-            </div>
-        </div>
-    {% endif %}
+  <div class="govuk-grid-row govuk-body">
+    <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-m">Linked schedules</h2>
+      {% if offence.schedules.length == 0 %}
+        <p class="govuk-!-margin-bottom-0">None</p>
+      {% else %}
+        {{ scheduleCards(offence.schedules) }}
+      {% endif %}
 
-    {{ govukButton({
-        classes: "govuk-button--secondary govuk-!-margin-right-2",
-        text: "Back",
-        preventDoubleClick: true,
-        href: searchUrl,
-        attributes: {  'data-qa': 'Back-view' }
-    }) }}
+    </div>
+  </div>
+
+  {% if not offence.isChild %}
+    <div class="govuk-grid-row govuk-body">
+      <div class="govuk-grid-column-full">
+        {% if not childOffences or childOffences.length == 0 %}
+          <h1 class="govuk-heading-m">Associated inchoate offences</h1>
+          <p class="govuk-!-margin-bottom-0">None</p>
+        {% else %}
+          <h1 class="govuk-heading-m">Associated inchoate offences</h1>
+          {{ inchoateTable(childOffences) }}
+        {% endif %}
+      </div>
+    </div>
+  {% endif %}
+
+  {{ govukButton({
+    classes: "govuk-button--secondary govuk-!-margin-right-2",
+    text: "Back",
+    preventDoubleClick: true,
+    href: searchUrl,
+    attributes: {  'data-qa': 'Back-view' }
+  }) }}
 
 {% endblock %}

--- a/server/views/pages/search/viewOffence.test.ts
+++ b/server/views/pages/search/viewOffence.test.ts
@@ -1,0 +1,50 @@
+import nunjucks, { Template } from 'nunjucks'
+import * as cheerio from 'cheerio'
+import fs from 'fs'
+import { registerNunjucks } from '../../../utils/nunjucksSetup'
+
+const snippet = fs.readFileSync('server/views/pages/search/viewOffence.njk')
+
+describe('VIEW_OFFENCE /', () => {
+  let compiledTemplate: Template
+  const njkEnv = registerNunjucks()
+
+  beforeEach(() => {
+    compiledTemplate = nunjucks.compile(snippet.toString(), njkEnv)
+  })
+
+  it('should render offence page when there are no markers', () => {
+    const context: Record<string, unknown> = {
+      user: { roles: [] },
+      offenceMarkers: {
+        markersExist: false,
+      },
+    }
+    const $ = cheerio.load(compiledTemplate.render(context))
+    const offenceMarkers = $('#offence-markers')
+    const noOffenceMarkers = $('#no-offence-markers')
+
+    expect(offenceMarkers.length).toBe(0)
+    expect(noOffenceMarkers.text()).toContain('None')
+  })
+
+  it('should render offence page with markers appropriately loaded', () => {
+    const context: Record<string, unknown> = {
+      user: { roles: [] },
+      offence: { code: 'AB', description: 'Offence 1' },
+      offenceMarkers: {
+        isSexual: true,
+        inListA: true,
+        markersExist: true,
+      },
+    }
+    const $ = cheerio.load(compiledTemplate.render(context))
+    const offenceMarkers = $('#offence-markers')
+
+    expect(offenceMarkers.length).toBe(1)
+    expect(offenceMarkers.find('li').length).toBe(2)
+    expect(offenceMarkers.text()).toContain('Sexual')
+    expect(offenceMarkers.text()).toContain('SDS >7 years between 01 April 2020 and 28 June 2022')
+    expect($('h1').text().trim()).toContain('AB: Offence 1')
+  })
+})

--- a/server/views/partials/offenceMarkersSection.njk
+++ b/server/views/partials/offenceMarkersSection.njk
@@ -1,0 +1,32 @@
+{% macro offenceMarkersSection(offenceMarkers) %}
+  <div class="govuk-grid-row govuk-body">
+    <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-m">Offence Markers: PCSC, Violent or Sexual</h2>
+      {% if offenceMarkers.markersExist %}
+        <ul class="govuk-list govuk-list--bullet" id="offence-markers">
+          {% if offenceMarkers.isSexual %}
+            <li>Sexual</li>
+          {% endif %}
+          {% if offenceMarkers.isViolent %}
+            <li>Violent</li>
+          {% endif %}
+          {% if offenceMarkers.inListA %}
+            <li>SDS >7 years between 01 April 2020 and 28 June 2022</li>
+          {% endif %}
+          {% if offenceMarkers.inListB %}
+            <li>SDS between 4 and 7 years after 28 June 2022</li>
+          {% endif %}
+          {% if offenceMarkers.inListC %}
+            <li>Sec250 >7 years after 28 June 2022</li>
+          {% endif %}
+          {% if offenceMarkers.inListD %}
+            <li>SDS >7 years after 28 June 2022</li>
+          {% endif %}
+        </ul>
+      {% else %}
+        <p id="no-offence-markers" class="govuk-!-margin-bottom-0">None</p>
+      {% endif %}
+    </div>
+  </div>
+
+{% endmacro %}


### PR DESCRIPTION

https://github.com/ministryofjustice/hmpps-manage-offences/assets/3595969/bf287208-3a25-4b5e-9f4c-8287106de88f

