### PR TITLE
MOP-159 Show the legislation text from both sources (from the schedule mapping or the offence)

### DIFF
--- a/server/views/partials/scheduleOffenceListTable.njk
+++ b/server/views/partials/scheduleOffenceListTable.njk
@@ -36,7 +36,7 @@
                         {{ offence.endDate | dateFormat }}
                     </td>
                     <td class="govuk-table__cell">
-                        {{ offence.legislationText }}
+                        {{ offence.legislationText or offence.legislation }}
                     </td>
                     {% if attributes.showMaxPeriodAndParagraph %}
                         <td class="govuk-table__cell">


### PR DESCRIPTION
Potentially a better way of dealing with this in the API ( OffenceToScheduleMappings arent really what we're returning)