### PR TITLE
Remove phase banner from application

### DIFF
--- a/integration_tests/e2e/signIn.cy.ts
+++ b/integration_tests/e2e/signIn.cy.ts
@@ -26,12 +26,6 @@ context('Sign In', () => {
     indexPage.headerUserName().should('contain.text', 'J. Smith')
   })
 
-  it('Phase banner visible in header', () => {
-    cy.signIn()
-    const indexPage = Page.verifyOnPage(IndexPage)
-    indexPage.headerPhaseBanner().should('contain.text', 'dev')
-  })
-
   it('User can sign out', () => {
     cy.signIn()
     const indexPage = Page.verifyOnPage(IndexPage)

--- a/integration_tests/pages/index.ts
+++ b/integration_tests/pages/index.ts
@@ -9,8 +9,6 @@ export default class IndexPage extends Page {
 
   courtRegisterLink = (): PageElement => cy.get('[href="/court-register"]')
 
-  headerPhaseBanner = (): PageElement => cy.get('[data-qa=header-phase-banner]')
-
   loadMonitorLink = (): PageElement => cy.get('[href="/load-results"]')
 
   toggleJobsLink = (): PageElement => cy.get('[href="/toggle-jobs"]')

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -18,7 +18,6 @@
 {% block beforeContent %}
 
   <aside role="complementary">
-    {% include "./phaseBanner.njk" %}
     {% block aside %}{% endblock %}
   </aside>
   <span class="govuk-visually-hidden" id="{{ pageId }}"></span>

--- a/server/views/partials/phaseBanner.njk
+++ b/server/views/partials/phaseBanner.njk
@@ -1,7 +1,0 @@
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-    tag: {
-        text: "alpha"
-    },
-    html: 'This is a new service'
-}) }}


### PR DESCRIPTION
Remove phase banner from application

- Deleted `phaseBanner.njk` partial template and references in `layout.njk`.
- Removed `headerPhaseBanner` element from `index.ts`.
- Deleted Cypress test for phase banner visibility in `signIn.cy.ts`.

This change simplifies the application by removing the phase banner, which is no longer required.